### PR TITLE
Explicitly select kubectl version; use alpine 3.7; tag for dirty

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,13 @@
-FROM alpine:3.6
+FROM alpine:3.7
+
+# get this by:
+# curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt
+ARG CLIVERSION=v1.10.5
 
 # need git and kubectl
 RUN apk --update add git curl gettext
 
-RUN curl -o /usr/local/bin/kubectl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
+RUN curl -o /usr/local/bin/kubectl -LO https://storage.googleapis.com/kubernetes-release/release/${CLIVERSION}/bin/linux/amd64/kubectl
 RUN chmod +x /usr/local/bin/kubectl
 
 ADD addons.sh /usr/local/bin

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,16 @@
 .PHONY: all tag image push
 
 IMAGE ?= deitch/kubernetes-addonmanager
-TAG ?= $(shell git show --format=%T -s)
+HASH ?= $(shell git show --format=%T -s)
+
+# check if we should append a dirty tag
+DIRTY ?= $(shell git diff-index --quiet HEAD -- ; echo $$?)
+ifneq ($(DIRTY),0)
+TAG = $(HASH)-dirty
+else
+TAG = $(HASH)
+endif
+
 
 all: push
 


### PR DESCRIPTION
As described:

* explicitly set kubectl version, rather than taking from latest
* base on alpine 3.7
* tag for dirty when building with unstaged or uncommitted changes
